### PR TITLE
Update for recording, white led control, zoom and focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ sendTo("reolink.0",{action: "snap"}, function(result){
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+* (Nibbels) [#56](https://github.com/aendue/ioBroker.reolink/issues/56) added function to switch scheduled recording on and off
 * (Nibbels) [#25](https://github.com/aendue/ioBroker.reolink/issues/25) detach led light from led light mode
 * (Nibbels) added setWhiteLedMode function
 * (Nibbels) read zoom and focus with POST request (works on RLC-823A v3.1)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you wish to have any specific API command included...just let me now.
  - IR Light
  - LED Light
  - Mail Notification
- 
+
 ### Example Usage of get image:
 
 ```
@@ -68,12 +68,17 @@ sendTo("reolink.0",{action: "snap"}, function(result){
 - RLC-522
 - RLC-810A
 - RLC-823A
+- Duo 3 PoE
 
 ## Changelog
 <!--
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+* (Nibbels) [#25](https://github.com/aendue/ioBroker.reolink/issues/25) detach led light from led light mode
+* (Nibbels) added setWhiteLedMode function
+* (Nibbels) read zoom and focus with POST request (works on RLC-823A v3.1)
+
 ### 1.0.3 (2024-01-21)
 * (oelison) [#49](https://github.com/aendue/ioBroker.reolink/issues/49)
 * (oelison) [#47](https://github.com/aendue/ioBroker.reolink/issues/47)

--- a/io-package.json
+++ b/io-package.json
@@ -1265,6 +1265,27 @@
       }
     },
     {
+      "_id": "settings.scheduledRecording",
+      "type": "state",
+      "common": {
+        "role": "state",
+        "name": {
+          "en": "Scheduled recording",
+          "de": "Zeitgesteuerte Aufzeichnung",
+          "pt": "Gravação programada",
+          "nl": "Geplande opname",
+          "fr": "Enregistrement programmé",
+          "it": "Registrazione programmata",
+          "es": "Grabación programada",
+          "pl": "Zaplanowane nagrywanie",
+          "zh-cn": "计划录制"
+        },
+        "type": "boolean",
+        "read": true,
+        "write": true
+      }
+    },
+    {
       "_id": "settings.playAlarm",
       "type": "state",
       "common": {

--- a/io-package.json
+++ b/io-package.json
@@ -1114,6 +1114,26 @@
       }
     },
     {
+      "_id": "settings.ledMode",
+      "type": "state",
+      "common": {
+        "role": "state",
+        "name": {
+          "en": "LED Mode",
+          "de": "LED Modus",
+          "nl": "LED Mode",
+          "fr": "LED Mode",
+          "it": "LED Modalità",
+          "es": "LED Modo",
+          "pl": "LED Tryb",
+          "zh-cn": "发光模式"
+        },
+        "type": "number",
+        "read": true,
+        "write": true
+      }
+    },
+    {
       "_id": "settings.ptzPreset",
       "type": "state",
       "common": {
@@ -1185,15 +1205,15 @@
       "common": {
         "role": "state",
         "name": {
-          "en": "auto focus",
-          "de": "autofokus",
+          "en": "auto focus disabled",
+          "de": "autofokus deaktiviert",
           "ru": "авто фокус",
-          "pt": "foco auto",
-          "nl": "automatisch",
-          "fr": "auto focus",
-          "it": "auto messa a fuoco",
-          "es": "enfoque automático",
-          "pl": "autofocus",
+          "pt": "foco auto desactivada",
+          "nl": "autofocus uitgeschakeld",
+          "fr": "autofocus désactivé",
+          "it": "autofocus disattivato",
+          "es": "enfoque desactivado",
+          "pl": "autofocus wyłączony",
           "zh-cn": "汽车重点"
         },
         "type": "string",
@@ -1221,6 +1241,27 @@
         "type": "number",
         "read": true,
         "write": true
+      }
+    },
+    {
+      "_id": "settings.focus",
+      "type": "state",
+      "common": {
+        "role": "state",
+        "name": {
+          "en": "focus level",
+          "de": "focus level",
+          "pt": "focus level",
+          "nl": "focusniveau",
+          "fr": "niveau de focalisation",
+          "it": "livello di concentrazione",
+          "es": "nivel de enfoque",
+          "pl": "poziom ostrości",
+          "zh-cn": "重点级"
+        },
+        "type": "number",
+        "read": true,
+        "write": false
       }
     },
     {

--- a/main.js
+++ b/main.js
@@ -84,7 +84,9 @@ class ReoLinkCam extends utils.Adapter {
 		await this.getDriveInfo();
 		await this.getPtzGuardInfo();
 		await this.getAutoFocus();
+		await this.getZoomAndFocus();
 		await this.getIrLights();
+		await this.getWhiteLed();
 
 		this.log.debug("getStateAsync start Email notification");
 		//create state dynamically
@@ -105,6 +107,7 @@ class ReoLinkCam extends utils.Adapter {
 		this.subscribeStates("settings.ir");
 		this.subscribeStates("settings.switchLed");
 		this.subscribeStates("settings.ledBrightness");
+		this.subscribeStates("settings.ledMode");
 		this.subscribeStates("settings.ptzPreset");
 		this.subscribeStates("settings.ptzPatrol");
 		this.subscribeStates("settings.autoFocus");
@@ -272,7 +275,6 @@ class ReoLinkCam extends utils.Adapter {
 		}
 	}
 	async getLocalLink(){
-
 		if (this.reolinkApiClient) {
 			try {
 				const LinkInfoValues = await this.reolinkApiClient.get(`/api.cgi?cmd=GetLocalLink&channel=0&user=${this.config.cameraUser}&password=${this.config.cameraPassword}`);
@@ -392,23 +394,23 @@ class ReoLinkCam extends utils.Adapter {
 		this.sendCmd(pushOnCmd,"SetPush");
 	}
 	async setAutoFocus(state) {
-		if (state == "Error or not supported"){
+		if (state == "Error or not supported") {
 			return;
 		}
-		if(state == "0" || state == "1"){
+		if (state == "0" || state == "1") {
 			const AutoFocusval = parseInt(state);
 			const autoFocusCmd = [{
 				"cmd": "SetAutoFocus",
 				"action": 0,
 				"param": {
 					"AutoFocus": {
-						"channel": 0,
+						"channel": this.config.cameraChannel,
 						"disable": AutoFocusval
 					}
 				}
 			}];
 			this.sendCmd(autoFocusCmd, "SetAutoFocus");
-		}else{
+		} else {
 			this.log.error("Value not supported!");
 			this.getAutoFocus();
 		}
@@ -416,7 +418,14 @@ class ReoLinkCam extends utils.Adapter {
 	async getAutoFocus(){
 		if (this.reolinkApiClient) {
 			try {
-				const AutoFocusValue = await this.reolinkApiClient.get(`/api.cgi?cmd=GetAutoFocus&channel=${this.config.cameraChannel}&user=${this.config.cameraUser}&password=${this.config.cameraPassword}`);
+				const getAutoFocusCmd = [{
+					"cmd": "GetAutoFocus",
+					"action": 0,
+					"param": {
+						"channel": this.config.cameraChannel,
+					}
+				}];
+				const AutoFocusValue = await this.reolinkApiClient.post(`/api.cgi?cmd=GetAutoFocus&user=${this.config.cameraUser}&password=${this.config.cameraPassword}`, getAutoFocusCmd);
 
 				this.log.debug(`AutoFocusValue ${JSON.stringify(AutoFocusValue.status)}: ${JSON.stringify(AutoFocusValue.data)}`);
 
@@ -425,12 +434,62 @@ class ReoLinkCam extends utils.Adapter {
 					await this.setStateAsync("network.connected", {val: this.apiConnected, ack: true});
 					const AutoFocus = AutoFocusValue.data[0];
 
-					if ("error" in AutoFocus){
+					if ("error" in AutoFocus) {
 						this.log.debug("Error or not supported " + this.getAutoFocus.name);
 						await this.setStateAsync("settings.autoFocus", {val: "Error or not supported", ack: true});
-					}else{
-						await this.setStateAsync("settings.autoFocus", {val: AutoFocus.value.AutoFocus.disable, ack: true});
+					} else {
+						// The datatype of the object is string.
+						// 1 means forbid (but is there any effect?)
+						// 0 means not disabled
+						const intState = AutoFocus.value.AutoFocus.disable;
+						if (intState === 0) {
+							await this.setStateAsync("settings.autoFocus", {val: "0", ack: true});
+						} else if (intState === 1) {
+							await this.setStateAsync("settings.autoFocus", {val: "1", ack: true});
+						} else {
+							await this.setStateAsync("settings.autoFocus", {val: "Unknown", ack: true});
+						}
 					}
+				}
+			} catch (error) {
+				this.apiConnected = false;
+				await this.setStateAsync("network.connected", {val: this.apiConnected, ack: true});
+				this.log.error(error);
+			}
+		}
+	}
+	async getZoomAndFocus(){
+		if (this.reolinkApiClient) {
+			try {
+				const getZoomFocusCmd = [{
+					"cmd": "GetZoomFocus",
+					"action": 0,
+					"param": {
+						"channel": this.config.cameraChannel,
+					}
+				}];
+				const ZoomFocusValue = await this.reolinkApiClient.post(`/api.cgi?cmd=GetZoomFocus&user=${this.config.cameraUser}&password=${this.config.cameraPassword}`, getZoomFocusCmd);
+
+				this.log.debug(`ZoomFocusValue ${JSON.stringify(ZoomFocusValue.status)}: ${JSON.stringify(ZoomFocusValue.data)}`);
+
+				if(ZoomFocusValue.status === 200) {
+					this.apiConnected = true;
+					await this.setStateAsync("network.connected", {val: this.apiConnected, ack: true});
+					const ZoomFocus = ZoomFocusValue.data[0];
+
+					if ("error" in ZoomFocus) {
+						this.log.debug("Error or not supported " + this.getZoomAndFocus.name);
+
+						return;
+					}
+
+					// zoom is the zoom position. See setZoomFocus()
+					const zoom = ZoomFocus.value.ZoomFocus.zoom.pos;
+					// the lens focus is adjusted during auto focus procedure.
+					const focus = ZoomFocus.value.ZoomFocus.focus.pos;
+
+					await this.setStateAsync("settings.setZoomFocus", {val: zoom, ack: true});
+					await this.setStateAsync("settings.focus", {val: focus, ack: true});
 				}
 			} catch (error) {
 				this.apiConnected = false;
@@ -445,7 +504,7 @@ class ReoLinkCam extends utils.Adapter {
 			"action": 0,
 			"param": {
 				"ZoomFocus": {
-					"channel": 0,
+					"channel": this.config.cameraChannel,
 					"pos": pos,
 					"op": "ZoomPos"
 				}
@@ -461,7 +520,7 @@ class ReoLinkCam extends utils.Adapter {
 				"alarm_mode": "times",
 				"manual_switch": 0,
 				"times": count,
-				"channel": 0
+				"channel": this.config.cameraChannel
 			}
 		}];
 		this.sendCmd(audioAlarmPlayCmd, "AudioAlarmPlay");
@@ -476,12 +535,12 @@ class ReoLinkCam extends utils.Adapter {
 				"action": 0,
 				"param": {
 					"IrLights": {
-						"channel": 0,
+						"channel": this.config.cameraChannel,
 						"state": irValue
 					}
 				}
 			}];
-			this.log.debug(irCmd);
+			this.log.debug(JSON.stringify(irCmd));
 			this.sendCmd(irCmd, "SetIrLights");
 		}else{
 			this.log.error("Value not supported!");
@@ -521,35 +580,60 @@ class ReoLinkCam extends utils.Adapter {
 		{
 			ledState = 1;
 		}
-		const setWhiteLedCmd = [{
+		const switchWhiteLedCmd = [{
 			"cmd": "SetWhiteLed",
 			"param": {
 				"WhiteLed": {
+					"channel": this.config.cameraChannel,
 					"state": ledState,
-					"channel": 0,
-					"mode": 1,
 				}
 			}
 		}];
-		this.sendCmd(setWhiteLedCmd, "SetWhiteLed");
+		this.sendCmd(switchWhiteLedCmd, "SetWhiteLed");
 	}
 	async setWhiteLed(state) {
-		const setWhiteLedCmd = [{
+		const setBrightnessCmd = [{
 			"cmd": "SetWhiteLed",
 			"param": {
 				"WhiteLed": {
-					"channel": 0,
-					"mode": 1,
+					"channel": this.config.cameraChannel,
 					"bright": state
 				}
 			}
 		}];
-		this.sendCmd(setWhiteLedCmd, "SetWhiteLed");
+		this.sendCmd(setBrightnessCmd, "SetWhiteLed");
+	}
+	async setWhiteLedMode(mode) {
+		// mode 0 = off        -> Manual switching. See https://github.com/aendue/ioBroker.reolink/issues/25 @johndoetheanimal for possible restrictions
+		// mode 1 = night mode -> Night Smart Mode
+		// mode 2 = unknown    -> Maybe `Always on at night` if supported.
+		// mode 3 = Timer mode -> Optional: [ { "cmd":"SetWhiteLed", "action":0, "param":{ "WhiteLed":{ "LightingSchedule":{ "EndHour":23, "EndMin":50, "StartHour":23, "StartMin":29 }, "mode":3, "channel":0 } } } ]
+		if (mode !== 0 && mode !== 1 && mode !== 2 && mode !== 3) {
+			this.log.error(`White Led mode ${mode} not supported!`);
+			return;
+		}
+		const setModeCmd = [{
+			"cmd": "SetWhiteLed",
+			"param": {
+				"WhiteLed": {
+					"channel": this.config.cameraChannel,
+					"mode": mode
+				}
+			}
+		}];
+		this.sendCmd(setModeCmd, "SetWhiteLed");
 	}
 	async getWhiteLed(){
 		if (this.reolinkApiClient) {
 			try {
-				const whiteLedValue = await this.reolinkApiClient.get(`/api.cgi?cmd=GetWhiteLeds&channel=${this.config.cameraChannel}&user=${this.config.cameraUser}&password=${this.config.cameraPassword}`);
+				const getLedCmd = [{
+					"cmd": "GetWhiteLed",
+					"action": 0,
+					"param": {
+						"channel": this.config.cameraChannel,
+					}
+				}];
+				const whiteLedValue = await this.reolinkApiClient.post(`/api.cgi?cmd=GetWhiteLed&channel=${this.config.cameraChannel}&user=${this.config.cameraUser}&password=${this.config.cameraPassword}`, getLedCmd);
 
 				this.log.debug(`whiteLedValue ${JSON.stringify(whiteLedValue.status)}: ${JSON.stringify(whiteLedValue.data)}`);
 
@@ -558,10 +642,13 @@ class ReoLinkCam extends utils.Adapter {
 					await this.setStateAsync("network.connected", {val: this.apiConnected, ack: true});
 
 					const whiteLed = whiteLedValue.data[0];
+					const brightness = whiteLed.value.WhiteLed.bright;
+					const mode = whiteLed.value.WhiteLed.mode;
+					const switchLed = whiteLed.value.WhiteLed.state ? true : false;
 
-					// 	this.log.info(MdValues.value.state);
-					await this.setStateAsync("settings.ledBrightness", {val: whiteLed.value.WhiteLed.bright, ack: true});
-
+					await this.setStateAsync("settings.ledBrightness", {val: brightness, ack: true});
+					await this.setStateAsync("settings.ledMode", {val: mode, ack: true});
+					await this.setStateAsync("settings.switchLed", {val: switchLed, ack: true});
 				}
 			} catch (error) {
 				this.apiConnected = false;
@@ -581,7 +668,7 @@ class ReoLinkCam extends utils.Adapter {
 			"action": 0,
 			"param": {
 				"PtzGuard": {
-					"channel": 0,
+					"channel": this.config.cameraChannel,
 					"cmdStr": "setPos",
 					"benable": enable,
 					"bSaveCurrentPos": 0
@@ -597,7 +684,7 @@ class ReoLinkCam extends utils.Adapter {
 			"action": 0,
 			"param": {
 				"PtzGuard": {
-					"channel": 0,
+					"channel": this.config.cameraChannel,
 					"cmdStr": "setPos",
 					"timeout": timeout,
 					"bSaveCurrentPos": 0
@@ -620,7 +707,7 @@ class ReoLinkCam extends utils.Adapter {
 		}
 
 
-		//Cretae new Timer (to re-run actions)
+		//Create new Timer (to re-run actions)
 		if(!this.apiConnected){
 			const notConnectedTimeout = 10;
 			this.refreshStateTimeout = this.setTimeout(() => {
@@ -782,6 +869,9 @@ class ReoLinkCam extends utils.Adapter {
 				}
 				if(propName === "ledBrightness") {
 					this.setWhiteLed(state.val);
+				}
+				if(propName === "ledMode") {
+					this.setWhiteLedMode(state.val);
 				}
 				if(propName === "getDiscData") {
 					this.getDriveInfo();


### PR DESCRIPTION
Servus :)

I did stumble across this issue some time ago https://github.com/aendue/ioBroker.reolink/issues/25
So I looked into it and worked on the adapter:
- I split led mode from white led enable/disable settings
- The adapter will now read led values (brightness, mode, switch) at adapter start. These values could be polled but I did not want to generate extra traffic until someone actually needs that.
- Added a setter function for white led mode (Off, Night Smart Mode, Unknown, Timer)
- Fix reading focus and zoom for ptz at adapter start. Focus is still a readonly because I could not find a way to set it to a specific integer value in the camera.
- When I switch to other waypoints I want to avoid the auto focus procedure because it is slow. I tempered with the request for `settings.autoFocus` until all API errors were gone, but I could not find an actual change in behaviour when I switched the autoFocus value between "disable" and "not disable" autofocus.

Please review what I did. I tested with my two cameras RLC-823A and Duo 3 PoE - all looks good so far - but I can never know if something broke on other cameras. My firmwares are up-to-date.

Regards Stefan