### PR TITLE
Added FTP support (like Push)

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -1204,6 +1204,28 @@
       }
     },
     {
+      "_id": "settings.ftp",
+      "type": "state",
+      "common": {
+        "role": "state",
+        "name": {
+          "en": "Enable FTP",
+          "de": "FTP einschalten",
+          "ru": "Активируйте FTP",
+          "pt": "Ativar o FTP",
+          "nl": "FTP activeren",
+          "fr": "Activer le FTP",
+          "it": "Attivare l'FTP",
+          "es": "Activar FTP",
+          "pl": "Aktywuj FTP",
+          "zh-cn": "激活 FTP"
+        },
+        "type": "boolean",
+        "read": true,
+        "write": true
+      }
+    },
+    {
       "_id": "settings.autoFocus",
       "type": "state",
       "common": {

--- a/main.js
+++ b/main.js
@@ -115,6 +115,7 @@ class ReoLinkCam extends utils.Adapter {
 		this.subscribeStates("settings.autoFocus");
 		this.subscribeStates("settings.setZoomFocus");
 		this.subscribeStates("settings.push");
+		this.subscribeStates("settings.ftp");
 		this.subscribeStates("settings.scheduledRecording");
 		this.subscribeStates("settings.playAlarm");
 		this.subscribeStates("settings.getDiscData");
@@ -395,6 +396,21 @@ class ReoLinkCam extends utils.Adapter {
 			}
 		}];
 		this.sendCmd(pushOnCmd,"SetPush");
+	}
+	async setFtp(state) {
+		let ftpOn = 1;
+		if(state == false) {
+			ftpOn = 0;
+		}
+		const ftpOnCmd = [{
+			"cmd": "SetFtpV20",
+			"param": {
+				"Ftp": {
+					"enable": ftpOn
+				}
+			}
+		}];
+		this.sendCmd(ftpOnCmd,"setFtp");
 	}
 	async setAutoFocus(state) {
 		if (state == "Error or not supported") {
@@ -936,6 +952,9 @@ class ReoLinkCam extends utils.Adapter {
 				}
 				if(propName === "push") {
 					this.setPush(state.val);
+				}
+				if(propName === "ftp") {
+					this.setFtp(state.val);
 				}
 				if(propName === "scheduledRecording") {
 					this.setScheduledRecording(state.val);


### PR DESCRIPTION
I needed to enable/disable Push _and_ FTP when I'm home or away. Push was already implemented, so I added the FTP support the same way. Just enable or disable (true|false).

- Tested on two RLC-510WA (FW v3.0.0.2429_23070602)
- Tested against [Camera HTTP API v8](https://drive.google.com/file/d/1KvPbjRVqsgCEzJsUS--zEyxw6cP-pkSI/view) (2023-04)
- Tested in iobroker v6.13.16 (via tar-Import)

![objects-iobroker](https://github.com/aendue/ioBroker.reolink/assets/102813397/5d71b816-e4a4-4f1e-9d29-5f1503bf5f47)
