### PR TITLE
Update test-and-release.yml - add node.js 22.x tests

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -40,7 +40,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [18.x, 20.x]
+                node-version: [18.x, 20.x, 22.x]
                 os: [ubuntu-latest, windows-latest, macos-latest]
 
         steps:


### PR DESCRIPTION
Test at node.js 22 are mandatore unless a known problem (and a corresponding issue) exists.