### PR TITLE
Query and allow setting/patching AiCfg

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -181,6 +181,28 @@
   "objects": [],
   "instanceObjects": [
     {
+      "_id": "ai_config",
+      "type": "channel",
+      "common": {
+        "name": "AI Config"
+      },
+      "native": {}
+    },
+    {
+      "_id": "ai_config.raw",
+      "type": "state",
+      "common": {
+        "role": "value",
+        "name": {
+          "en": "Raw AI Config"
+        },
+        "type": "json",
+        "read": true,
+        "write": false
+      },
+      "native": {}
+    },
+    {
       "_id": "sensor",
       "type": "channel",
       "common": {

--- a/io-package.json
+++ b/io-package.json
@@ -198,7 +198,7 @@
         },
         "type": "json",
         "read": true,
-        "write": false
+        "write": true
       },
       "native": {}
     },

--- a/main.js
+++ b/main.js
@@ -142,6 +142,7 @@ class ReoLinkCam extends utils.Adapter {
         this.subscribeStates("settings.ptzCheck");
         this.subscribeStates("settings.ptzGuardTimeout");
         this.subscribeStates("Command.Reboot");
+        this.subscribeStates("ai_config.*");
     }
     //function for getting motion detection
     async getMdState() {
@@ -320,6 +321,24 @@ class ReoLinkCam extends utils.Adapter {
                 ack: true,
             });
         }
+    }
+
+    async setAiCfg(jsonString) {
+        try {
+            const command = [
+                {
+                    cmd: "SetAiCfg",
+                    param: JSON.parse(jsonString),
+                },
+            ];
+
+            await this.sendCmd(command, "SetAiCfg");
+        } catch (error) {
+            this.log.error(`setAiCfg: ${error}`);
+        }
+
+        // Immediately after patching the settings, get the new settings.
+        await this.getAiCfg();
     }
 
     //function for getting general information of camera device
@@ -1318,6 +1337,12 @@ class ReoLinkCam extends utils.Adapter {
                 const idValues = id.split(".");
                 const propName = idValues[idValues.length - 1];
                 this.log.info(`Changed state: ${propName}`);
+
+                if (id.endsWith("ai_config.raw")) {
+                    this.setAiCfg(state.val);
+                    return;
+                }
+
                 if (propName == "ir") {
                     this.setIrLights(state.val);
                 }


### PR DESCRIPTION
Hello, 

Thank you for creating and/or maintaining this adapter.

I'm new to Reolink cameras, and I wanted to disable or enable the Auto Tracking feature of my E1 Pro Outdoor (where the cam follows/tracks a detected object).

Since the corresponding ReoLink API (`GetAiCfg`, `SetAiCfg`) is not supported by the adapter, I wrote some code to request the AiCfg JSON and allow setting/patching it. Patching works by just setting the keys you want to change, e.g.

```json
{
  "bSmartTrack": 0
}
```

to disable the Auto Tracking feature.

I created a new `ai_config.raw` state that can later be expanded to provide e.g. a boolean state for just the Auto Tracking feature.

Let me know what you think!